### PR TITLE
Auto-Locate MATLAB from base image & minor cleanup to increase uniformity

### DIFF
--- a/matlab-vnc/Dockerfile
+++ b/matlab-vnc/Dockerfile
@@ -1,16 +1,31 @@
 # Copyright 2020 The MathWorks, Inc.
 
-# Replace "matlab:r2020b" with the Docker image that contains MATLAB
-# MATLAB should be installed at /usr/local/MATLAB or other changes will need
-# to be made to this Dockerfile
-FROM matlab:r2020b AS matlab-install-stage
+# Argument shared across multi-stage build to hold location of installed MATLAB 
+ARG BASE_ML_INSTALL_LOC=/tmp/matlab-install-location
+
+# Replace "matlab" with the Docker image that contains MATLAB
+# MATLAB should be available on the path in the Docker image
+FROM matlab AS matlab-install-stage
+ARG BASE_ML_INSTALL_LOC
+
+# Run code to locate a MATLAB install in the base image and softlink
+# to BASE_ML_INSTALL_LOC for a latter stage to copy 
+RUN export ML_INSTALL_LOC=$(which matlab) \
+    && if [ ! -z "$ML_INSTALL_LOC" ]; then \
+        ML_INSTALL_LOC=$(dirname $(dirname $(readlink -f ${ML_INSTALL_LOC}))); \
+        echo "soft linking: " $ML_INSTALL_LOC " to" ${BASE_ML_INSTALL_LOC}; \
+        ln -s ${ML_INSTALL_LOC} ${BASE_ML_INSTALL_LOC}; \
+    else echo "MATLAB was not found in your image."; exit 1; \
+    fi
 
 FROM jupyter/base-notebook
+ARG BASE_ML_INSTALL_LOC
 
+# Switch to root user
 USER root
 
 # Copy MATLAB install from Docker image
-COPY --from=matlab-install-stage /usr/local/MATLAB /usr/local/MATLAB
+COPY --from=matlab-install-stage ${BASE_ML_INSTALL_LOC} /usr/local/MATLAB
 
 # Add MATLAB to the path
 RUN ln -s /usr/local/MATLAB/bin/matlab /usr/local/bin/matlab

--- a/matlab-vnc/Dockerfile
+++ b/matlab-vnc/Dockerfile
@@ -15,7 +15,10 @@ RUN export ML_INSTALL_LOC=$(which matlab) \
         ML_INSTALL_LOC=$(dirname $(dirname $(readlink -f ${ML_INSTALL_LOC}))); \
         echo "soft linking: " $ML_INSTALL_LOC " to" ${BASE_ML_INSTALL_LOC}; \
         ln -s ${ML_INSTALL_LOC} ${BASE_ML_INSTALL_LOC}; \
-    else echo "MATLAB was not found in your image."; exit 1; \
+    elif [ $BASE_ML_INSTALL_LOC = '/tmp/matlab-install-location' ]; then \
+        echo "MATLAB was not found in your image."; exit 1; \
+    else \
+        echo "Proceeding with user provided path to MATLAB installation: ${BASE_ML_INSTALL_LOC}"; \
     fi
 
 FROM jupyter/base-notebook

--- a/matlab-vnc/Dockerfile.mounted
+++ b/matlab-vnc/Dockerfile.mounted
@@ -2,9 +2,10 @@
 
 FROM jupyter/base-notebook
 
+# Switch to root user
 USER root
 
-# Add MATLAB to the path
+# Put MATLAB on the PATH
 RUN ln -s /usr/local/MATLAB/bin/matlab /usr/local/bin/matlab
 
 # Install MATLAB dependencies
@@ -93,7 +94,7 @@ RUN mkdir -p ${NOVNC_PATH} \
      | tar -zxf - -C ${NOVNC_PATH} --strip=1 \
      && chown -R ${NB_USER}:users ${NOVNC_PATH}
 
-# Change user to jovyan from root as we do not want any changes to be made as root in the container
+# Switch back to notebook user
 USER $NB_USER
 
 # Get websockify

--- a/matlab-vnc/MATLAB_mounted.md
+++ b/matlab-vnc/MATLAB_mounted.md
@@ -12,10 +12,10 @@ docker build -f Dockerfile.mounted -t matlab-vnc-notebook-nomatlab .
 
 ### Start the Docker Container
 
-Execute the command below to start a Docker container, bind mount the directory `/usr/local/MATLAB/R2020a` (which must contain a MATLAB R2020b or later 64 bit Linux installation) into the directory `/usr/local/MATLAB` inside the container, and bind port 8888 on the host to port 8888 of the container (by default, Jupyter's app-server runs on port 8888 inside the container):
+Execute the command below to start a Docker container, bind mount the root directory of your local install of MATLAB `/usr/local/MATLAB/R2020b` into the directory `/usr/local/MATLAB` inside the container, and bind port 8888 on the host to port 8888 of the container (by default, Jupyter's app-server runs on port 8888 inside the container):
 
 ```bash
-docker run -it -v /usr/local/MATLAB/R2020a:/usr/local/MATLAB:ro -p 8888:8888 matlab-vnc-notebook-nomatlab
+docker run -it -v /usr/local/MATLAB/R2020b:/usr/local/MATLAB:ro -p 8888:8888 matlab-vnc-notebook-nomatlab
 ```
 
 Access the Jupyter Notebook by following one of the URLs displayed in the output of the ```docker run``` command.

--- a/matlab-vnc/README.md
+++ b/matlab-vnc/README.md
@@ -19,7 +19,7 @@ The `Dockerfile` in this repository builds upon the base image `jupyter/base-not
 
 To build the Docker image, follow these steps:
 
-1. Select a base container image with a MATLAB R2020b or later (64 bit Linux) installation. If you need to create one, follow the steps at [Create a MATLAB Container Image](https://github.com/mathworks-ref-arch/matlab-dockerfile).
+1. Select a base container image with a MATLAB (64 bit Linux) installation. If you need to create one, follow the steps at [Create a MATLAB Container Image](https://github.com/mathworks-ref-arch/matlab-dockerfile).
 
 2. Open the `Dockerfile`, replace the name `matlab` with the name of the MATLAB image from step 1:
 

--- a/matlab-vnc/README.md
+++ b/matlab-vnc/README.md
@@ -28,7 +28,7 @@ To build the Docker image, follow these steps:
    ```
 
 3. MATLAB should be on the path in the image built used in step 1.
-   If it is not available, then edit the following line to point to you MATLAB installation:
+   If it is not available, then edit the following line to point to your MATLAB installation:
 
    ```
    COPY --from=matlab-install-stage ${BASE_ML_INSTALL_LOC} /usr/local/MATLAB

--- a/matlab-vnc/README.md
+++ b/matlab-vnc/README.md
@@ -27,7 +27,7 @@ To build the Docker image, follow these steps:
    FROM matlab AS matlab-install-stage
    ```
 
-3. MATLAB should be on the path in the image built used in step 1.
+3. MATLAB must be on the system path in the image built in step 1.
    If not, then edit the following line to point to your MATLAB installation:
 
    ```

--- a/matlab-vnc/README.md
+++ b/matlab-vnc/README.md
@@ -27,19 +27,21 @@ To build the Docker image, follow these steps:
    FROM matlab AS matlab-install-stage
    ```
 
-3. If MATLAB is not installed at the location `/usr/local/MATLAB` in the image built in step 1, edit the following line to point to you MATLAB installation:
+3. MATLAB should be on the path in the image built used in step 1.
+   If it is not available, then edit the following line to point to you MATLAB installation:
 
    ```
-   COPY --from=matlab-install-stage /usr/local/MATLAB /usr/local/MATLAB
+   COPY --from=matlab-install-stage ${BASE_ML_INSTALL_LOC} /usr/local/MATLAB
    ```
 
-   For example, if MATLAB is installed at the location `/opt/matlab/R2020a` change the line above to:
+   For example, if MATLAB is installed at the location `/opt/matlab/R2020b` change the line above to:
 
    ```
-   COPY --from=matlab-install-stage /opt/matlab/R2020a /usr/local/MATLAB
+   COPY --from=matlab-install-stage /opt/matlab/R2020b /usr/local/MATLAB
    ```
+   and delete all lines in the Dockerfile that use the variable `BASE_ML_INSTALL_LOC`
 
-4. Optionally, to preconfigure a network license manager, open the `Dockerfile`, uncomment the line below, and replace `port@hostname` with the licence server address:
+4. (Optional) To preconfigure a network license manager, open the `Dockerfile`, uncomment the line below, and replace `port@hostname` with the licence server address:
 
    ```
     # ENV MLM_LICENSE_FILE port@hostname

--- a/matlab-vnc/README.md
+++ b/matlab-vnc/README.md
@@ -28,18 +28,17 @@ To build the Docker image, follow these steps:
    ```
 
 3. MATLAB should be on the path in the image built used in step 1.
-   If it is not available, then edit the following line to point to your MATLAB installation:
+   If not, then edit the following line to point to your MATLAB installation:
 
    ```
-   COPY --from=matlab-install-stage ${BASE_ML_INSTALL_LOC} /usr/local/MATLAB
+   ARG BASE_ML_INSTALL_LOC=/tmp/matlab-install-location
    ```
 
    For example, if MATLAB is installed at the location `/opt/matlab/R2020b` change the line above to:
 
    ```
-   COPY --from=matlab-install-stage /opt/matlab/R2020b /usr/local/MATLAB
+   ARG BASE_ML_INSTALL_LOC=/opt/matlab/R2020b
    ```
-   and delete all lines in the Dockerfile that use the variable `BASE_ML_INSTALL_LOC`
 
 4. (Optional) To preconfigure a network license manager, open the `Dockerfile`, uncomment the line below, and replace `port@hostname` with the licence server address:
 

--- a/matlab/Dockerfile
+++ b/matlab/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2020 The MathWorks, Inc.
 
 # Argument shared across multi-stage build to hold location of installed MATLAB 
-ARG BASE_ML_INSTALL_LOC=/tmp/matlab-install-location
+ARG BASE_ML_INSTALL_LOC=/tmp/matlab-install-location3
 
 # Replace "matlab" with the Docker image that contains MATLAB
 # MATLAB should be available on the path in the Docker image
@@ -15,7 +15,10 @@ RUN export ML_INSTALL_LOC=$(which matlab) \
         ML_INSTALL_LOC=$(dirname $(dirname $(readlink -f ${ML_INSTALL_LOC}))); \
         echo "soft linking: " $ML_INSTALL_LOC " to" ${BASE_ML_INSTALL_LOC}; \
         ln -s ${ML_INSTALL_LOC} ${BASE_ML_INSTALL_LOC}; \
-    else echo "MATLAB was not found in your image."; exit 1; \
+    elif [ $BASE_ML_INSTALL_LOC = '/tmp/matlab-install-location' ]; then \
+        echo "MATLAB was not found in your image."; exit 1; \
+    else \
+        echo "Proceeding with user provided path to MATLAB installation: ${BASE_ML_INSTALL_LOC}"; \
     fi
 
 FROM jupyter/base-notebook

--- a/matlab/Dockerfile
+++ b/matlab/Dockerfile
@@ -1,14 +1,34 @@
 # Copyright 2020 The MathWorks, Inc.
 
+# Argument shared across multi-stage build to hold location of installed MATLAB 
+ARG BASE_ML_INSTALL_LOC=/tmp/matlab-install-location
+
 # Replace "matlab" with the Docker image that contains MATLAB
-# MATLAB should be installed at /usr/local/MATLAB or other changes will need
-# to be made to this Dockerfile
-FROM matlab AS matlab-install-stage
+# MATLAB should be available on the path in the Docker image
+FROM matlab:r2020b AS matlab-install-stage
+ARG BASE_ML_INSTALL_LOC
+
+# Run code to locate a MATLAB install in the base image and softlink
+# to BASE_ML_INSTALL_LOC for a latter stage to copy 
+RUN export ML_INSTALL_LOC=$(which matlab) \
+    && if [ ! -z "$ML_INSTALL_LOC" ]; then \
+        ML_INSTALL_LOC=$(dirname $(dirname $(readlink -f ${ML_INSTALL_LOC}))); \
+        echo "soft linking: " $ML_INSTALL_LOC " to" ${BASE_ML_INSTALL_LOC}; \
+        ln -s ${ML_INSTALL_LOC} ${BASE_ML_INSTALL_LOC}; \
+    else echo "MATLAB was not found in your image."; exit 1; \
+    fi
 
 FROM jupyter/base-notebook
+ARG BASE_ML_INSTALL_LOC
 
 # Switch to root user
 USER root
+
+# Copy MATLAB install from supplied Docker image
+COPY --from=matlab-install-stage ${BASE_ML_INSTALL_LOC} /usr/local/MATLAB
+
+# Put MATLAB on the PATH
+RUN ln -s /usr/local/MATLAB/bin/matlab /usr/local/bin/matlab
 
 # Install MATLAB dependencies
 # Reference: https://github.com/mathworks-ref-arch/container-images/tree/master/matlab-deps
@@ -70,12 +90,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -
         xvfb \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-
-# Put MATLAB on the PATH
-RUN ln -s /usr/local/MATLAB/bin/matlab /usr/local/bin/matlab
-
-# Copy MATLAB install from supplied Docker image
-COPY --from=matlab-install-stage /usr/local/MATLAB /usr/local/MATLAB
 
 # Switch back to notebook user
 USER $NB_USER

--- a/matlab/Dockerfile
+++ b/matlab/Dockerfile
@@ -1,11 +1,11 @@
 # Copyright 2020 The MathWorks, Inc.
 
 # Argument shared across multi-stage build to hold location of installed MATLAB 
-ARG BASE_ML_INSTALL_LOC=/tmp/matlab-install-location3
+ARG BASE_ML_INSTALL_LOC=/tmp/matlab-install-location
 
 # Replace "matlab" with the Docker image that contains MATLAB
 # MATLAB should be available on the path in the Docker image
-FROM matlab:r2020b AS matlab-install-stage
+FROM matlab AS matlab-install-stage
 ARG BASE_ML_INSTALL_LOC
 
 # Run code to locate a MATLAB install in the base image and softlink

--- a/matlab/Dockerfile.mounted
+++ b/matlab/Dockerfile.mounted
@@ -5,6 +5,9 @@ FROM jupyter/base-notebook
 # Switch to root user
 USER root
 
+# Put MATLAB on the PATH
+RUN ln -s /usr/local/MATLAB/bin/matlab /usr/local/bin/matlab
+
 # Install MATLAB dependencies
 # Reference: https://github.com/mathworks-ref-arch/container-images/tree/master/matlab-deps
 RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install --no-install-recommends -y \
@@ -65,9 +68,6 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get update && apt-get install -
         xvfb \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-
-# Put MATLAB on the PATH
-RUN ln -s /usr/local/MATLAB/bin/matlab /usr/local/bin/matlab
 
 # Switch back to notebook user
 USER $NB_USER

--- a/matlab/README.md
+++ b/matlab/README.md
@@ -28,7 +28,7 @@ To build the Docker image, follow these steps:
    ```
 
 3. MATLAB should be on the path in the image built used in step 1.
-   If it is not available, then edit the following line to point to you MATLAB installation:
+   If it is not available, then edit the following line to point to your MATLAB installation:
 
    ```
    COPY --from=matlab-install-stage ${BASE_ML_INSTALL_LOC} /usr/local/MATLAB

--- a/matlab/README.md
+++ b/matlab/README.md
@@ -27,10 +27,11 @@ To build the Docker image, follow these steps:
    FROM matlab AS matlab-install-stage
    ```
 
-3. If MATLAB is not installed at the location `/usr/local/MATLAB` in the image built in step 1, edit the following line to point to you MATLAB installation:
+3. MATLAB should be on the path in the image built used in step 1.
+   If it is not available, then edit the following line to point to you MATLAB installation:
 
    ```
-   COPY --from=matlab-install-stage /usr/local/MATLAB /usr/local/MATLAB
+   COPY --from=matlab-install-stage ${BASE_ML_INSTALL_LOC} /usr/local/MATLAB
    ```
 
    For example, if MATLAB is installed at the location `/opt/matlab/R2020b` change the line above to:
@@ -38,8 +39,9 @@ To build the Docker image, follow these steps:
    ```
    COPY --from=matlab-install-stage /opt/matlab/R2020b /usr/local/MATLAB
    ```
+   and delete all lines in the Dockerfile that use the variable `BASE_ML_INSTALL_LOC`
 
-4. Optionally, to preconfigure a network license manager, open the `Dockerfile`, uncomment the line below, and replace `port@hostname` with the licence server address:
+4. (Optional) To preconfigure a network license manager, open the `Dockerfile`, uncomment the line below, and replace `port@hostname` with the licence server address:
 
    ```
     # ENV MLM_LICENSE_FILE port@hostname

--- a/matlab/README.md
+++ b/matlab/README.md
@@ -27,7 +27,7 @@ To build the Docker image, follow these steps:
    FROM matlab AS matlab-install-stage
    ```
 
-3. MATLAB should be on the path in the image built used in step 1.
+3. MATLAB must be on the system path in the image built in step 1.
    If not, then edit the following line to point to your MATLAB installation:
 
    ```

--- a/matlab/README.md
+++ b/matlab/README.md
@@ -28,18 +28,17 @@ To build the Docker image, follow these steps:
    ```
 
 3. MATLAB should be on the path in the image built used in step 1.
-   If it is not available, then edit the following line to point to your MATLAB installation:
+   If not, then edit the following line to point to your MATLAB installation:
 
    ```
-   COPY --from=matlab-install-stage ${BASE_ML_INSTALL_LOC} /usr/local/MATLAB
+   ARG BASE_ML_INSTALL_LOC=/tmp/matlab-install-location
    ```
 
    For example, if MATLAB is installed at the location `/opt/matlab/R2020b` change the line above to:
 
    ```
-   COPY --from=matlab-install-stage /opt/matlab/R2020b /usr/local/MATLAB
+   ARG BASE_ML_INSTALL_LOC=/opt/matlab/R2020b
    ```
-   and delete all lines in the Dockerfile that use the variable `BASE_ML_INSTALL_LOC`
 
 4. (Optional) To preconfigure a network license manager, open the `Dockerfile`, uncomment the line below, and replace `port@hostname` with the licence server address:
 


### PR DESCRIPTION
matlab/Dockerfile & matlab-vnc/Dockerfile will automatically use the location of the MATLAB install found in the image provided.
matlab/README.md & matlab-vnc/README.md have been updated to reflect this.

Other minor clean up to make all increase uniformity between Dockerfiles.
Minor updates to README files to improve correctness.