### PR TITLE
Switch default Ubuntu version to 24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ ARG LICENSE_SERVER
 ARG NLM=${LICENSE_SERVER:+"-with-nlm"}
 
 # Both 22.04 & 24.04 ship with Python 3.11
-ARG UBUNTU_VERSION=22.04
+ARG UBUNTU_VERSION=24.04
 
 ######################################
 #  Stage 1 : Base Layer + matlab-deps


### PR DESCRIPTION
Since all the Matlab versions are now supporting 24.04[[1]] while some of them are not, switching default Ubuntu image version will avoid issues when user only specify Matlab version.

[1]: https://github.com/mathworks-ref-arch/container-images/tree/main/matlab-deps